### PR TITLE
Handle errors properly

### DIFF
--- a/src/DI/NegotiationPlugin.php
+++ b/src/DI/NegotiationPlugin.php
@@ -6,6 +6,7 @@ use Apitte\Core\Decorator\IDecorator;
 use Apitte\Core\DI\ApiExtension;
 use Apitte\Core\DI\Helpers;
 use Apitte\Core\DI\Plugin\AbstractPlugin;
+use Apitte\Core\DI\Plugin\CoreDecoratorPlugin;
 use Apitte\Core\DI\Plugin\PluginCompiler;
 use Apitte\Core\Exception\Logical\InvalidStateException;
 use Apitte\Negotiation\ContentNegotiation;
@@ -41,8 +42,8 @@ class NegotiationPlugin extends AbstractPlugin
 	 */
 	public function loadPluginConfiguration(): void
 	{
-		if (!$this->compiler->getPlugin('decorator')) {
-			throw new InvalidStateException(sprintf('Plugin "CoreDecoratorPlugin" must be enabled'));
+		if (!$this->compiler->getPlugin(CoreDecoratorPlugin::PLUGIN_NAME)) {
+			throw new InvalidStateException(sprintf('Plugin "%s" must be enabled', CoreDecoratorPlugin::class));
 		}
 
 		$builder = $this->getContainerBuilder();
@@ -51,21 +52,25 @@ class NegotiationPlugin extends AbstractPlugin
 
 		$builder->addDefinition($this->prefix('transformer.json'))
 			->setFactory(JsonTransformer::class)
+			->addSetup('setDebugMode', [$globalConfig['debug']])
 			->addTag(ApiExtension::NEGOTIATION_TRANSFORMER_TAG, ['suffix' => 'json'])
 			->setAutowired(false);
 
 		$builder->addDefinition($this->prefix('transformer.csv'))
 			->setFactory(CsvTransformer::class)
+			->addSetup('setDebugMode', [$globalConfig['debug']])
 			->addTag(ApiExtension::NEGOTIATION_TRANSFORMER_TAG, ['suffix' => 'csv'])
 			->setAutowired(false);
 
 		$builder->addDefinition($this->prefix('transformer.fallback'))
 			->setFactory(JsonTransformer::class)
+			->addSetup('setDebugMode', [$globalConfig['debug']])
 			->addTag(ApiExtension::NEGOTIATION_TRANSFORMER_TAG, ['suffix' => '*', 'fallback' => '*'])
 			->setAutowired(false);
 
 		$builder->addDefinition($this->prefix('transformer.renderer'))
 			->setFactory(RendererTransformer::class)
+			->addSetup('setDebugMode', [$globalConfig['debug']])
 			->addTag(ApiExtension::NEGOTIATION_TRANSFORMER_TAG, ['suffix' => '#'])
 			->setAutowired(false);
 
@@ -94,10 +99,12 @@ class NegotiationPlugin extends AbstractPlugin
 
 			$builder->addDefinition($this->prefix('transformer.fallback'))
 				->setFactory(JsonUnifyTransformer::class)
+				->addSetup('setDebugMode', [$globalConfig['debug']])
 				->addTag(ApiExtension::NEGOTIATION_TRANSFORMER_TAG, ['suffix' => '*', 'fallback' => '*'])
 				->setAutowired(false);
 			$builder->addDefinition($this->prefix('transformer.json'))
 				->setFactory(JsonUnifyTransformer::class)
+				->addSetup('setDebugMode', [$globalConfig['debug']])
 				->addTag(ApiExtension::NEGOTIATION_TRANSFORMER_TAG, ['suffix' => 'json'])
 				->setAutowired(false);
 		}

--- a/src/Transformer/AbstractTransformer.php
+++ b/src/Transformer/AbstractTransformer.php
@@ -9,11 +9,21 @@ use Apitte\Negotiation\Http\AbstractEntity;
 abstract class AbstractTransformer implements ITransformer
 {
 
+	/** @var bool */
+	protected $debug = false;
+
 	protected function getEntity(ApiResponse $response): AbstractEntity
 	{
-		if (!$entity = $response->getEntity()) throw new InvalidStateException('Entity is required');
+		if (!$entity = $response->getEntity()) {
+			throw new InvalidStateException('Entity is required');
+		}
 
 		return $entity;
+	}
+
+	public function setDebugMode(bool $debug): void
+	{
+		$this->debug = $debug;
 	}
 
 }

--- a/src/Transformer/JsonTransformer.php
+++ b/src/Transformer/JsonTransformer.php
@@ -21,6 +21,11 @@ class JsonTransformer extends AbstractTransformer
 		if (isset($context['exception'])) {
 			// Convert exception to json
 			$content = Json::encode($this->extractException($request, $response, $context));
+			if ($context['exception'] instanceof ClientErrorException || $context['exception'] instanceof ServerErrorException) {
+				$response = $response->withStatus($context['exception']->getCode());
+			} else {
+				$response = $response->withStatus(500);
+			}
 		} else {
 			// Convert data to array to json
 			$content = Json::encode($this->extractData($request, $response, $context));
@@ -29,10 +34,8 @@ class JsonTransformer extends AbstractTransformer
 		$response->getBody()->write($content);
 
 		// Setup content type
-		$response = $response
+		return $response
 			->withHeader('Content-Type', 'application/json');
-
-		return $response;
 	}
 
 	/**
@@ -51,14 +54,13 @@ class JsonTransformer extends AbstractTransformer
 	protected function extractException(ApiRequest $request, ApiResponse $response, array $context): array
 	{
 		$exception = $context['exception'];
-		$data = ['exception' => $exception->getMessage()];
+		$data = [];
 
-		if ($exception instanceof ClientErrorException) {
+		if ($exception instanceof ClientErrorException || $exception instanceof ServerErrorException) {
+			$data['exception'] = $exception->getMessage();
 			$data['context'] = $exception->getContext();
-		}
-
-		if ($exception instanceof ServerErrorException) {
-			$data['context'] = $exception->getContext();
+		} else {
+			$data['exception'] = $this->debug ? $exception->getMessage() : 'Application encountered an internal error. Please try again later.';
 		}
 
 		return $data;

--- a/tests/cases/SuffixNegotiator.phpt
+++ b/tests/cases/SuffixNegotiator.phpt
@@ -10,6 +10,7 @@ use Apitte\Core\Exception\Logical\InvalidStateException;
 use Apitte\Core\Http\ApiRequest;
 use Apitte\Core\Http\ApiResponse;
 use Apitte\Core\Schema\Endpoint;
+use Apitte\Core\Schema\EndpointHandler;
 use Apitte\Core\Schema\EndpointNegotiation;
 use Apitte\Negotiation\Http\ArrayEntity;
 use Apitte\Negotiation\SuffixNegotiator;
@@ -43,14 +44,15 @@ test(function (): void {
 test(function (): void {
 	$negotiation = new SuffixNegotiator(['json' => new JsonTransformer()]);
 
-	$enpoint = new Endpoint();
-	$enpoint->addNegotiation($en = new EndpointNegotiation());
-	$en->setSuffix('.json');
+	$handler = new EndpointHandler('class', 'method');
+
+	$endpoint = new Endpoint($handler);
+	$endpoint->addNegotiation($en = new EndpointNegotiation('.json'));
 
 	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal()->withNewUri('https://contributte.org/foo.json'));
 	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 	$response = $response->withEntity(ArrayEntity::from(['foo' => 'bar']))
-		->withEndpoint($enpoint);
+		->withEndpoint($endpoint);
 
 	// 2# Negotiate response (PSR7 body contains encoded json data)
 	$res = $negotiation->negotiate($request, $response);


### PR DESCRIPTION
All transformers:
- set error code (from exception in case of ClientErrorException and ServerErrorException, 500 otherwise)
- show message from exception only in debug mode (for ClientErrorException and ServerErrorException is always shown original message)